### PR TITLE
posix-ify `grab_latest.sh`

### DIFF
--- a/grab_latest.sh
+++ b/grab_latest.sh
@@ -1,70 +1,58 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 MANIFEST_FILE="net.imput.helium.yml"
 METADATA_FILE="net.imput.helium.metainfo.xml"
 REPO_URL="https://github.com/imputnet/helium-linux/releases/download"
 
 if [ -f "fetch.config.yml" ]; then
-    ALLOW_PRERELEASE=$(grep -m1 'allow-prerelease:' fetch.config.yml | awk '{print $2}')
+    ALLOW_PRERELEASE=$(grep 'allow-prerelease:' fetch.config.yml | head -1 | awk '{print $2}')
 else
     ALLOW_PRERELEASE="false"
 fi
 
-echo "   Fetching releases from GitHub..."
-RELEASES_JSON=$(curl -s https://api.github.com/repos/imputnet/helium-linux/releases)
-
-read -r LATEST_VERSION IS_PRERELEASE <<< $(echo "$RELEASES_JSON" | python3 -c "
-import sys, json
-try:
-    data = json.load(sys.stdin)
-    allow_pre = '${ALLOW_PRERELEASE}' == 'true'
-    if not isinstance(data, list):
-        print('null false')
-        sys.exit(0)
-    candidates = [r for r in data if r.get('tag_name') and (allow_pre or not r.get('prerelease', False))]
-    if candidates:
-        latest = sorted(candidates, key=lambda x: x.get('created_at', ''))[-1]
-        print(f\"{latest['tag_name']} {str(latest['prerelease']).lower()}\")
-    else:
-        print('null false')
-except Exception:
-    print('null false')
-")
-
-if [[ -z "$LATEST_VERSION" || "$LATEST_VERSION" == "null" ]]; then
-  echo "   Error: Failed to fetch valid version tag from GitHub."
-  exit 1
+if [ "$ALLOW_PRERELEASE" = "true" ]; then
+    FILTER="true"
+else
+    FILTER=".prerelease == false"
 fi
 
-CURRENT_VERSION=$(grep -Po 'helium-[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?' "$MANIFEST_FILE" | head -n1 | grep -Po '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?')
+printf "   Fetching releases from GitHub...\n"
+RELEASES_JSON=$(curl -s https://api.github.com/repos/imputnet/helium-linux/releases |
+    jq -c "[.[] | select(.tag_name != null and ($FILTER))] | sort_by(.created_at) | last")
+LATEST_VERSION=$(printf "%s" "$RELEASES_JSON" | jq -r '.tag_name')
+IS_PRERELEASE=$(printf "%s" "$RELEASES_JSON" | jq -r '.prerelease')
+
+if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
+    printf "   Error: Failed to fetch valid version tag from GitHub.\n"
+    exit 1
+fi
+
+CURRENT_VERSION=$(grep 'helium-[0-9]' "$MANIFEST_FILE" | head -1 | sed 's/.*helium-\([0-9.]*\).*/\1/')
 CURRENT_DATE=$(date '+%Y-%m-%d')
 
-echo "version: $CURRENT_VERSION" > version.txt
-echo "prerelease: $IS_PRERELEASE" >> version.txt
+printf "version: %s\nprerelease: %s\n" "$LATEST_VERSION" "$IS_PRERELEASE" > version.txt
 
-if [[ "$CURRENT_VERSION" == "$LATEST_VERSION" ]]; then
-  echo "   Manifest is already up to date ($CURRENT_VERSION)."
-  # We exit successfully; the workflow will see no git diff and stop.
-  exit 0
-else
-  echo "   Updating manifest from $CURRENT_VERSION → $LATEST_VERSION"
-  if [[ "$OSTYPE" == "darwin"* ]]; then SED_INPLACE="sed -i ''"; else SED_INPLACE="sed -i"; fi
-
-  # --- Update Manifest Files ---
-  $SED_INPLACE -E "s|(helium-linux/releases/download/)$CURRENT_VERSION|\1$LATEST_VERSION|g" "$MANIFEST_FILE"
-  $SED_INPLACE -E "s|(helium-$CURRENT_VERSION-x86_64_linux)|helium-$LATEST_VERSION-x86_64_linux|g" "$MANIFEST_FILE"
-  $SED_INPLACE -E "s|(helium-$CURRENT_VERSION-arm64_linux)|helium-$LATEST_VERSION-arm64_linux|g" "$MANIFEST_FILE"
-  
-  $SED_INPLACE -E "s|(<release version=['\"])$CURRENT_VERSION|\1$LATEST_VERSION|g" "$METADATA_FILE"
-  $SED_INPLACE -E "s|(<release date=['\"])[0-9]{4}-[0-9]{2}-[0-9]{2}|\1$CURRENT_DATE|g" "$METADATA_FILE"
-  
-  # Update the version tracker
-  echo "version: $LATEST_VERSION" > version.txt
-  echo "prerelease: $IS_PRERELEASE" >> version.txt
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+    printf "   Manifest is already up to date (%s).\n" "$CURRENT_VERSION"
+    # We exit successfully; the workflow will see no git diff and stop.
+    exit 0
 fi
 
-echo "   Downloading binaries to compute SHA256..."
+printf "   Updating manifest from %s -> %s\n" "$CURRENT_VERSION" "$LATEST_VERSION"
+
+# Update Manifest Files
+sed "s|helium-linux/releases/download/${CURRENT_VERSION}|helium-linux/releases/download/${LATEST_VERSION}|g" "$MANIFEST_FILE" > "_" && mv "_" "$MANIFEST_FILE"
+sed "s|helium-${CURRENT_VERSION}-x86_64_linux|helium-${LATEST_VERSION}-x86_64_linux|g" "$MANIFEST_FILE" > "_" && mv "_" "$MANIFEST_FILE"
+sed "s|helium-${CURRENT_VERSION}-arm64_linux|helium-${LATEST_VERSION}-arm64_linux|g" "$MANIFEST_FILE" > "_" && mv "_" "$MANIFEST_FILE"
+
+sed "s|version=\"${CURRENT_VERSION}\"|version=\"${LATEST_VERSION}\"|g" "$METADATA_FILE" > "_" && mv "_" "$METADATA_FILE"
+sed "s|date=\"[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\"|date=\"${CURRENT_DATE}\"|g" "$METADATA_FILE" > "_" && mv "_" "$METADATA_FILE"
+
+# Update the version tracker
+printf "version: %s\nprerelease: %s\n" "$LATEST_VERSION" "$IS_PRERELEASE" > version.txt
+
+printf "   Downloading binaries to compute SHA256...\n"
 
 DL_X86="$REPO_URL/$LATEST_VERSION/helium-$LATEST_VERSION-x86_64_linux.tar.xz"
 TMP_X86=$(mktemp)
@@ -78,16 +66,17 @@ curl -L -s -o "$TMP_ARM" "$DL_ARM"
 NEW_SHA256_ARM=$(sha256sum "$TMP_ARM" | awk '{print $1}')
 rm -f "$TMP_ARM"
 
-if [[ -z "$NEW_SHA256_X86" || -z "$NEW_SHA256_ARM" ]]; then
-  echo "   Failed to compute SHA256 checksums."
-  exit 1
+if [ -z "$NEW_SHA256_X86" ] || [ -z "$NEW_SHA256_ARM" ]; then
+    printf "   Failed to compute SHA256 checksums.\n"
+    exit 1
 fi
 
-echo "   New x86_64 SHA256: $NEW_SHA256_X86"
-echo "   New aarch64 SHA256: $NEW_SHA256_ARM"
+printf "   New x86_64 SHA256: %s\n   New aarch64 SHA256: %s\n" "$NEW_SHA256_X86" "$NEW_SHA256_ARM"
 
 # This finds the URL line for each architecture, moves to the next line (n), and replaces the hash.
-$SED_INPLACE -E "/x86_64_linux\.tar\.xz/{n;s/sha256: [a-f0-9]+/sha256: $NEW_SHA256_X86/;}" "$MANIFEST_FILE"
-$SED_INPLACE -E "/arm64_linux\.tar\.xz/{n;s/sha256: [a-f0-9]+/sha256: $NEW_SHA256_ARM/;}" "$MANIFEST_FILE"
+sed "/x86_64_linux\.tar\.xz/{n;s/sha256: [a-f0-9]*/sha256: $NEW_SHA256_X86/;}" "$MANIFEST_FILE" > "_" && mv "_" "$MANIFEST_FILE"
+sed "/arm64_linux\.tar\.xz/{n;s/sha256: [a-f0-9]*/sha256: $NEW_SHA256_ARM/;}" "$MANIFEST_FILE" > "_" && mv "_" "$MANIFEST_FILE"
 
-echo "   Manifest updated successfully."
+printf "   Manifest updated successfully.\n"
+
+printf "   Done.\n"


### PR DESCRIPTION
Make grab_latest.sh portable and posix-compliant, while also simplifying it.
Adds dependency `jq` back since python is much more messy than a dedicated json parser.