### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -7,6 +7,9 @@ on:
   #    - completed
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ShyVortex/helium-flatpak/security/code-scanning/2](https://github.com/ShyVortex/helium-flatpak/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/build-flatpak.yml` at the workflow root so token scope is documented and stable.  
Since this workflow publishes to `gh-pages` via `GITHUB_TOKEN`, it requires repository contents write access; the minimal functional setting is:

- `contents: write`

This preserves existing behavior (push to `gh-pages`) while resolving the “no explicit permissions” finding. Place the block after `on:` (or before `jobs:`) at top level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
